### PR TITLE
fix colon in bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ Add the following snippet to your .bashrc:
             while [ $i -ge 0 ]; do
                 [ ${COMP_WORDS[$((i--))]} == ":" ] && break
             done
-            if [ $i -le 0 ]; then
-                cur=${COMP_WORDS[COMP_CWORD]}
-            else
+            if [ $i -gt 0 ]; then
                 cur=$(printf "%s" ${COMP_WORDS[@]:$i})
             fi
         fi


### PR DESCRIPTION
If bash-completion takes colon as a word breaker, `${COMP_WORDS[COMP_CWORD]}` will not get the complete nose search path. 

This pull request detects if colon is used for a breaker, and adds the previous word into the final parameter to `nosecomplete`.
