### PR TITLE
Fix minor python 3 compatibility issue

### DIFF
--- a/nosecomplete.py
+++ b/nosecomplete.py
@@ -123,7 +123,7 @@ def main():
         "-s",
         "--search-method",
         help="Search method to use when locating tests",
-        choices=methods.keys(),
+        choices=list(methods.keys()),
         default='python',
     )
     (options, args) = parser.parse_args()


### PR DESCRIPTION
Hello!
I've tried to use nosecomplete with python 3.3 and encountered following error:

```
$ nosecomplete
Traceback (most recent call last):
File "/home/iley/.virtualenvs/cms3k/bin/nosecomplete", line 9, in <module>
load_entry_point('nosecomplete==0.1.0', 'console_scripts', 'nosecomplete')()
File "/home/iley/.virtualenvs/cms3k/lib/python3.3/site-packages/nosecomplete-0.1.0-py3.3.egg/nosecomplete.py", line 127, in main
default='python',
File "/usr/lib/python3.3/optparse.py", line 1004, in add_option
option = self.option_class(*args, **kwargs)
File "/usr/lib/python3.3/optparse.py", line 579, in __init__
checker(self)
File "/usr/lib/python3.3/optparse.py", line 674, in _check_choice
% str(type(self.choices)).split("'")[1], self)
optparse.OptionError: option -s/--search-method: choices must be a list of strings ('dict_keys' supplied)
```

Turns out `choices` argument of `OptionParser.add_option()` only accepts lists and `dict.keys()` returns `builtins.dict_keys` in python 3.
