### PR TITLE
improve(nosetests.fish): use tr instead of sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ fish
 
     ```fish
     function __fish_nosetests
-      set -l file (commandline -ot)
-      command nosecomplete $file ^/dev/null | sed -e 's/ /\n/g'
+        set -l file (commandline -ot)
+        command nosecomplete $file ^/dev/null | tr ' ' '\n'
     end
     complete -f -c nosetests -a '(__fish_nosetests)' -d 'Nosetests'
     ```


### PR DESCRIPTION
OS X's `sed` does not support `/n` what renders `nosecomplete` useless on such system. Using `tr` instead solves that problem.

Of course, one could install GNU sed and alias `sed` to it, but I believe using `tr` instead is better/simpler.

What do you think?